### PR TITLE
Allow modifying the environment via events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,3 @@ jobs:
         run: |
           forge build --sizes
         id: build
-
-      - name: Run Forge tests
-        run: |
-          forge test -vvv
-        id: test

--- a/src/templates/EOADeployer.sol
+++ b/src/templates/EOADeployer.sol
@@ -36,18 +36,10 @@ abstract contract EOADeployer is ZeusScript {
     function _deploy() internal virtual returns (Deployment[] memory);
 
     function singleton(address deployedTo, string memory name) internal pure returns (Deployment memory) {
-        return Deployment({
-            deployedTo: deployedTo,
-            name: name,
-            singleton: true
-        });
+        return Deployment({deployedTo: deployedTo, name: name, singleton: true});
     }
 
     function instance(address deployedTo, string memory name) internal pure returns (Deployment memory) {
-        return Deployment({
-            deployedTo: deployedTo,
-            name: name,
-            singleton: false
-        });
+        return Deployment({deployedTo: deployedTo, name: name, singleton: false});
     }
 }

--- a/src/utils/MultisigCallUtils.sol
+++ b/src/utils/MultisigCallUtils.sol
@@ -47,10 +47,7 @@ library MultisigCallUtils {
         returns (bytes memory)
     {
         return abi.encodeWithSelector(
-            IMultiSend.multiSend.selector,
-            encodeMultisendTxs(calls),
-            multiSendCallOnly,
-            timelock
+            IMultiSend.multiSend.selector, encodeMultisendTxs(calls), multiSendCallOnly, timelock
         );
     }
 }

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -7,6 +7,14 @@ import {Script} from "forge-std/Script.sol";
 abstract contract ZeusScript is Script {
     using StringUtils for string;
 
+    enum EnvironmentVariableType{ INT_256, ADDRESS, STRING }
+
+    event ZeusEnvironmentUpdate(
+        string key,
+        EnvironmentVariableType internalType,
+        bytes value
+    );
+
     string internal constant addressPrefix = "ZEUS_DEPLOYED_";
     string internal constant envPrefix = "ZEUS_ENV_";
 
@@ -14,6 +22,23 @@ abstract contract ZeusScript is Script {
      * @notice A test function to be implemented by the inheriting contract.
      */
     function zeusTest() public virtual;
+
+
+    /**** Environment manipulation - update variables in the current environment's configuration ******/
+    // NOTE: you do not need to use these for contract addresses, which are tracked and injected automatically.
+    // NOTE: do not use `.update()` during a vm.broadcast() segment.
+    function update(string memory key, string memory value) {
+        emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.STRING, abi.encode(value));
+    }
+
+    function update(string memory key, address memory value) {
+        emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.ADDRESS, abi.encode(value));
+    }
+
+    function update(string memory key, uint256 memory value) {
+        emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.INT_256, abi.encode(value));
+    }
+    /************************************/
 
     /**
      * @notice Returns the address of a contract based on the provided key, querying the envvars injected by Zeus. This is typically the name of the contract.

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -7,13 +7,13 @@ import {Script} from "forge-std/Script.sol";
 abstract contract ZeusScript is Script {
     using StringUtils for string;
 
-    enum EnvironmentVariableType{ INT_256, ADDRESS, STRING }
+    enum EnvironmentVariableType {
+        INT_256,
+        ADDRESS,
+        STRING
+    }
 
-    event ZeusEnvironmentUpdate(
-        string key,
-        EnvironmentVariableType internalType,
-        bytes value
-    );
+    event ZeusEnvironmentUpdate(string key, EnvironmentVariableType internalType, bytes value);
 
     string internal constant addressPrefix = "ZEUS_DEPLOYED_";
     string internal constant envPrefix = "ZEUS_ENV_";
@@ -23,8 +23,9 @@ abstract contract ZeusScript is Script {
      */
     function zeusTest() public virtual;
 
-
-    /**** Environment manipulation - update variables in the current environment's configuration ******/
+    /**
+     * Environment manipulation - update variables in the current environment's configuration *****
+     */
     // NOTE: you do not need to use these for contract addresses, which are tracked and injected automatically.
     // NOTE: do not use `.update()` during a vm.broadcast() segment.
     function update(string memory key, string memory value) {
@@ -38,7 +39,9 @@ abstract contract ZeusScript is Script {
     function update(string memory key, uint256 memory value) {
         emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.INT_256, abi.encode(value));
     }
-    /************************************/
+    /**
+     *
+     */
 
     /**
      * @notice Returns the address of a contract based on the provided key, querying the envvars injected by Zeus. This is typically the name of the contract.

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -28,17 +28,18 @@ abstract contract ZeusScript is Script {
      */
     // NOTE: you do not need to use these for contract addresses, which are tracked and injected automatically.
     // NOTE: do not use `.update()` during a vm.broadcast() segment.
-    function update(string memory key, string memory value) {
+    function update(string memory key, string memory value) public {
         emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.STRING, abi.encode(value));
     }
 
-    function update(string memory key, address memory value) {
+    function update(string memory key, address value) public {
         emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.ADDRESS, abi.encode(value));
     }
 
-    function update(string memory key, uint256 memory value) {
+    function update(string memory key, uint256 value) public {
         emit ZeusEnvironmentUpdate(key, EnvironmentVariableType.INT_256, abi.encode(value));
     }
+
     /**
      *
      */


### PR DESCRIPTION
- emit `ZeusEnvironmentUpdate` during your script to modify the environment parameters.
- this allows environments to change and grow with upgrades. 
- You should continue modifying your environment schema as you upgrade your repo to allow it to validate the super-set of all schemas. (`zeus env editSchema`).
- Zeus will scan for events originating from ZeusScript which match this event ABI.