### PR TITLE
Updated templates

### DIFF
--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -28,7 +28,7 @@ abstract contract MultisigBuilder is ZeusScript {
         // creates and return SafeTx object
         // assumes 0 value (ETH) being sent to multisig
 
-        address multiSendCallOnly = zeusAddress(multiSendCallOnlyName);
+        address multiSendCallOnly = zAddress(multiSendCallOnlyName);
 
         return SafeTx({to: multiSendCallOnly, value: 0, data: data, op: EncGnosisSafe.Operation.DelegateCall});
     }

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -41,73 +41,40 @@ abstract contract ZeusScript is Script {
     }
 
     /**
-     *
-     */
-
-    /**
      * @notice Returns the address of a contract based on the provided key, querying the envvars injected by Zeus. This is typically the name of the contract.
      * @param key The key to look up the address for. Should be the contract name, with an optional suffix if deploying multiple instances. (E.g. "MyContract_1" and "MyContract_2")
      * @return The address of the contract associated with the provided key. Reverts if envvar not found.
      */
-    function zeusAddress(string memory key) internal view returns (address) {
+    function zAddress(string memory key) internal view returns (address) {
+        //                     ZEUS_DEPLOYED_ + key
         string memory envvar = addressPrefix.concat(key);
         return vm.envAddress(envvar);
     }
 
-    function getUint64(string memory key) internal view returns (uint64) {
+    /**
+     * Returns a uin64 set in the current environment.
+     * @param key The environment key. Corresponds to a ZEUS_* env variable.
+     */
+    function zUint64(string memory key) internal view returns (uint64) {
         string memory envvar = envPrefix.concat(key);
         return uint64(vm.envUint(envvar));
     }
 
-    //////////////////////////
-    /// HELPER FUNCTIONS /////
-    //////////////////////////
-
-    function _ethPos() internal view returns (address) {
-        return zeusAddress("ethPOS");
+    /**
+     * Returns a boolean set in the current environment.
+     * @param key The environment key. Corresponds to a ZEUS_* env variable.
+     */
+    function zBool(string memory key) internal view returns (bool) {
+        string memory envvar = envPrefix.concat(key);
+        return bool(vm.envBool(envvar));
     }
 
-    function _eigenpodGenesisTime() internal view returns (uint64) {
-        return getUint64("EIGENPOD_GENESIS_TIME");
-    }
-
-    function _eigenPodManagerPendingImpl() internal view returns (address) {
-        return zeusAddress("EigenPodManager_pendingImpl");
-    }
-
-    function _operationsMultisig() internal view returns (address) {
-        return zeusAddress("OperationsMultisig");
-    }
-
-    function _pauserRegistry() internal view returns (address) {
-        return zeusAddress("PauserRegistry");
-    }
-
-    function _proxyAdmin() internal view returns (address) {
-        return zeusAddress("ProxyAdmin");
-    }
-
-    function _eigenPodManagerProxy() internal view returns (address) {
-        return zeusAddress("EigenPodManager_proxy");
-    }
-
-    function _eigenPodBeacon() internal view returns (address) {
-        return zeusAddress("EigenPod_beacon");
-    }
-
-    function _eigenPodPendingImpl() internal view returns (address) {
-        return zeusAddress("EigenPod_pendingImpl");
-    }
-
-    function _multiSendCallOnly() internal view returns (address) {
-        return zeusAddress("MultiSendCallOnly");
-    }
-
-    function _timelock() internal view returns (address) {
-        return zeusAddress("Timelock");
-    }
-
-    function _executorMultisig() internal view returns (address) {
-        return zeusAddress("ExecutorMultisig");
+    /**
+     * Returns a string set in the current environment
+     * @param key The environment key. Corresponds to a ZEUS_* env variable.
+     */
+    function zString(string memory key) internal view returns (string memory) {
+        string memory envvar = envPrefix.concat(key);
+        return vm.envString(envvar);
     }
 }


### PR DESCRIPTION
- Expose bool / string as additional types.
- Make the builtin functions shorter (zAddress vs. zeusAddress) and consistently named (zeusAddress => zAddress, getUint64() => zUint64())
- Remove EL specifics and move them into the eigenlayer contracts repo to avoid leaking the abstraction...