### PR TITLE
Updated format for upgrade scripts

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,4 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 
+
+solc_version = '0.8.12'
+
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/interfaces/ISafe.sol
+++ b/src/interfaces/ISafe.sol
@@ -17,7 +17,7 @@ interface ISafe {
     function execTransaction(
         address to,
         uint256 value,
-        bytes calldata data,
+        bytes memory data,
         uint8 operation,
         uint256 safeTxGas,
         uint256 baseGas,

--- a/src/interfaces/ITimelock.sol
+++ b/src/interfaces/ITimelock.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.12;
 
 interface ITimelock {
-
     function delay() external view returns (uint256);
 
     function queuedTransactions(bytes32) external view returns (bool);

--- a/src/interfaces/ITimelock.sol
+++ b/src/interfaces/ITimelock.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.12;
 
 interface ITimelock {
+
+    function delay() external view returns (uint256);
+
     function queuedTransactions(bytes32) external view returns (bool);
 
     function queueTransaction(address target, uint256 value, string memory signature, bytes memory data, uint256 eta)

--- a/src/templates/EOADeployer.sol
+++ b/src/templates/EOADeployer.sol
@@ -26,15 +26,14 @@ abstract contract EOADeployer is ZeusScript {
      * @notice Deploys contracts based on the configuration specified in the provided environment file.
      * Emits via ZeusDeploy event.
      */
-    function deploy() public {
-        // return deployment info
-        _deploy();
+    function runAsEOA() public {
+        _runAsEOA();
     }
 
     /**
      * @dev Internal function to deploy contracts based on the provided addresses, environment, and parameters.
      */
-    function _deploy() internal virtual;
+    function _runAsEOA() internal virtual;
 
     function deploySingleton(address deployedTo, string memory name) internal {
         emit ZeusDeploy(name, deployedTo, true /* singleton */ );

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -21,8 +21,6 @@ abstract contract MultisigBuilder is ZeusScript {
     function execute() public {
         address multisigContext = getMultisigContext();
         vm.startPrank(multisigContext, multisigContext);
-        console.log("- establishing multisig spoof");
-        console.log(multisigContext);
         _runAsMultisig();
         vm.stopPrank();
     }

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -25,7 +25,7 @@ abstract contract MultisigBuilder is ZeusScript {
 
     /**
      * @notice To be implemented by inheriting contract.
-     * 
+     *
      * This function will be pranked from the perspective of the multisig you choose to run with.
      * DO NOT USE vm.startPrank()/stopPrank() during your implementation.
      */

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -18,7 +18,7 @@ abstract contract MultisigBuilder is ZeusScript {
      * @notice Constructs a SafeTx object for a Gnosis Safe to ingest. Emits via `ZeusMultisigExecute`
      */
     function execute() public {
-        vm.startPrank(zAddress("MULTISIG"));
+        vm.startPrank(getMultisigContext());
         _runAsMultisig();
         vm.stopPrank();
     }

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -4,11 +4,12 @@ pragma solidity ^0.8.12;
 import {ZeusScript} from "../utils/ZeusScript.sol";
 import {MultisigCall, MultisigCallUtils} from "../utils/MultisigCallUtils.sol";
 import {SafeTx, EncGnosisSafe} from "../utils/SafeTxUtils.sol";
+import {console} from "forge-std/console.sol";
+
 /**
  * @title MultisigBuilder
  * @dev Abstract contract for building arbitrary multisig scripts.
  */
-
 abstract contract MultisigBuilder is ZeusScript {
     using MultisigCallUtils for MultisigCall[];
 
@@ -18,7 +19,10 @@ abstract contract MultisigBuilder is ZeusScript {
      * @notice Constructs a SafeTx object for a Gnosis Safe to ingest. Emits via `ZeusMultisigExecute`
      */
     function execute() public {
-        vm.startPrank(getMultisigContext());
+        address multisigContext = getMultisigContext();
+        vm.startPrank(multisigContext);
+        console.log("- establishing multisig spoof");
+        console.log(multisigContext);
         _runAsMultisig();
         vm.stopPrank();
     }

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -19,7 +19,7 @@ abstract contract MultisigBuilder is ZeusScript {
      */
     function execute() public {
         vm.startPrank(zAddress("MULTISIG"));
-        runAsMultisig();
+        _runAsMultisig();
         vm.stopPrank();
     }
 
@@ -29,5 +29,5 @@ abstract contract MultisigBuilder is ZeusScript {
      * This function will be pranked from the perspective of the multisig you choose to run with.
      * DO NOT USE vm.startPrank()/stopPrank() during your implementation.
      */
-    function runAsMultisig() internal virtual;
+    function _runAsMultisig() internal virtual;
 }

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -20,7 +20,7 @@ abstract contract MultisigBuilder is ZeusScript {
      */
     function execute() public {
         address multisigContext = getMultisigContext();
-        vm.startPrank(multisigContext);
+        vm.startPrank(multisigContext, multisigContext);
         console.log("- establishing multisig spoof");
         console.log(multisigContext);
         _runAsMultisig();

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -18,23 +18,16 @@ abstract contract MultisigBuilder is ZeusScript {
      * @notice Constructs a SafeTx object for a Gnosis Safe to ingest. Emits via `ZeusMultisigExecute`
      */
     function execute() public {
-        // get calls for Multisig from inheriting script
-        MultisigCall[] memory calls = _execute();
-
-        // encode calls as MultiSend data
-        bytes memory data = calls.encodeMultisendTxs();
-
-        // creates and return SafeTx object
-        // assumes 0 value (ETH) being sent to multisig
-
-        address multiSendCallOnly = zAddress(multiSendCallOnlyName);
-
-        emit ZeusMultisigExecute(multiSendCallOnly, 0, data, EncGnosisSafe.Operation.DelegateCall);
+        vm.startPrank(zAddress("MULTISIG"));
+        runAsMultisig();
+        vm.stopPrank();
     }
 
     /**
      * @notice To be implemented by inheriting contract.
-     * @return An array of MultisigCall objects.
+     * 
+     * This function will be pranked from the perspective of the multisig you choose to run with.
+     * DO NOT USE vm.startPrank()/stopPrank() during your implementation.
      */
-    function _execute() internal virtual returns (MultisigCall[] memory);
+    function runAsMultisig() internal virtual;
 }

--- a/src/utils/EncGnosisSafe.sol
+++ b/src/utils/EncGnosisSafe.sol
@@ -43,7 +43,18 @@ library EncGnosisSafe {
 
         return abi.encodeCall(
             ISafe.execTransaction,
-            (to, value, data, uint8(op), SAFE_TX_GAS, BASE_GAS, GAS_PRICE, GAS_TOKEN, REFUND_RECEIVER, sig)
+            (
+                to, 
+                value, 
+                data, 
+                uint8(op), 
+                SAFE_TX_GAS, 
+                BASE_GAS, 
+                GAS_PRICE, 
+                GAS_TOKEN, 
+                REFUND_RECEIVER, 
+                sig
+            )
         );
     }
 }

--- a/src/utils/EncGnosisSafe.sol
+++ b/src/utils/EncGnosisSafe.sol
@@ -15,7 +15,7 @@ library EncGnosisSafe {
     address constant GAS_TOKEN = address(uint160(0));
     address constant REFUND_RECEIVER = payable(address(uint160(0)));
 
-    function execTransaction(address from, address to, bytes memory data, Operation op)
+    function calldataToExecTransaction(address from, address to, bytes memory data, Operation op)
         internal
         pure
         returns (bytes memory)
@@ -23,7 +23,7 @@ library EncGnosisSafe {
         return encodeForExecutor(from, to, 0, data, op);
     }
 
-    function execTransaction(address from, address to, uint256 value, bytes memory data, Operation op)
+    function calldataToExecTransaction(address from, address to, uint256 value, bytes memory data, Operation op)
         internal
         pure
         returns (bytes memory)

--- a/src/utils/EncGnosisSafe.sol
+++ b/src/utils/EncGnosisSafe.sol
@@ -36,6 +36,7 @@ library EncGnosisSafe {
         pure
         returns (bytes memory)
     {
+        // magic value for signature.
         bytes1 v = bytes1(uint8(1));
         bytes32 r = bytes32(uint256(uint160(from)));
         bytes32 s;

--- a/src/utils/EncGnosisSafe.sol
+++ b/src/utils/EncGnosisSafe.sol
@@ -13,7 +13,7 @@ library EncGnosisSafe {
     uint256 constant BASE_GAS = 0;
     uint256 constant GAS_PRICE = 0;
     address constant GAS_TOKEN = address(uint160(0));
-    address constant REFUND_RECEIVER = payable(address(uint160(0)));
+    address payable constant REFUND_RECEIVER = payable(address(uint160(0)));
 
     function calldataToExecTransaction(address from, address to, bytes memory data, Operation op)
         internal
@@ -36,26 +36,14 @@ library EncGnosisSafe {
         pure
         returns (bytes memory)
     {
-        // magic value for signature.
         bytes1 v = bytes1(uint8(1));
         bytes32 r = bytes32(uint256(uint160(from)));
         bytes32 s;
         bytes memory sig = abi.encodePacked(r, s, v);
 
-        bytes memory final_calldata_to_executor_multisig = abi.encodeWithSelector(
-            ISafe.execTransaction.selector,
-            to,
-            value,
-            data,
-            op,
-            SAFE_TX_GAS,
-            BASE_GAS,
-            GAS_PRICE,
-            GAS_TOKEN,
-            REFUND_RECEIVER,
-            sig
+        return abi.encodeCall(
+            ISafe.execTransaction,
+            (to, value, data, uint8(op), SAFE_TX_GAS, BASE_GAS, GAS_PRICE, GAS_TOKEN, REFUND_RECEIVER, sig)
         );
-
-        return final_calldata_to_executor_multisig;
     }
 }

--- a/src/utils/EncGnosisSafe.sol
+++ b/src/utils/EncGnosisSafe.sol
@@ -43,18 +43,7 @@ library EncGnosisSafe {
 
         return abi.encodeCall(
             ISafe.execTransaction,
-            (
-                to, 
-                value, 
-                data, 
-                uint8(op), 
-                SAFE_TX_GAS, 
-                BASE_GAS, 
-                GAS_PRICE, 
-                GAS_TOKEN, 
-                REFUND_RECEIVER, 
-                sig
-            )
+            (to, value, data, uint8(op), SAFE_TX_GAS, BASE_GAS, GAS_PRICE, GAS_TOKEN, REFUND_RECEIVER, sig)
         );
     }
 }

--- a/src/utils/MultisigCallUtils.sol
+++ b/src/utils/MultisigCallUtils.sol
@@ -30,7 +30,7 @@ library MultisigCallUtils {
         return multisigCalls;
     }
 
-    function encodeMultisendTxs(MultisigCall[] memory txs) public pure returns (bytes memory) {
+    function encodeMultisendTxs(IMultiSend ms, MultisigCall[] memory txs) public pure returns (bytes memory) {
         bytes memory ret = new bytes(0);
         for (uint256 i = 0; i < txs.length; i++) {
             ret = abi.encodePacked(
@@ -38,16 +38,6 @@ library MultisigCallUtils {
             );
         }
 
-        return abi.encodeWithSelector(IMultiSend.multiSend.selector, ret);
-    }
-
-    function makeExecutorCalldata(MultisigCall[] memory calls, address multiSendCallOnly, address timelock)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodeWithSelector(
-            IMultiSend.multiSend.selector, encodeMultisendTxs(calls), multiSendCallOnly, timelock
-        );
+        return abi.encodeCall(ms.multiSend, ret);
     }
 }

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -255,6 +255,19 @@ abstract contract ZeusScript is Script, Test {
     }
 
     /**
+     * Returns a uin64 set in the current environment.
+     * @param key The environment key. Corresponds to a ZEUS_* env variable.
+     */
+    function zUint256(string memory key) public view returns (uint256) {
+        if (updatedTypes[key] != EnvironmentVariableType.UNMODIFIED) {
+            return updatedUInt256s[key];
+        }
+
+        string memory envvar = envPrefix.concat(key);
+        return uint256(vm.envUint(envvar));
+    }
+
+    /**
      * Returns a boolean set in the current environment.
      * @param key The environment key. Corresponds to a ZEUS_* env variable.
      */

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -205,6 +205,32 @@ abstract contract ZeusScript is Script, Test {
     }
 
     /**
+     * Returns a uin16 set in the current environment.
+     * @param key The environment key. Corresponds to a ZEUS_* env variable.
+     */
+    function zUint16(string memory key) public view returns (uint16) {
+        if (updatedTypes[key] != EnvironmentVariableType.UNMODIFIED) {
+            return updatedUInt16s[key];
+        }
+
+        string memory envvar = envPrefix.concat(key);
+        return uint16(vm.envUint(envvar));
+    }
+
+    /**
+     * Returns a uin16 set in the current environment.
+     * @param key The environment key. Corresponds to a ZEUS_* env variable.
+     */
+    function zUint8(string memory key) public view returns (uint8) {
+        if (updatedTypes[key] != EnvironmentVariableType.UNMODIFIED) {
+            return updatedUInt8s[key];
+        }
+
+        string memory envvar = envPrefix.concat(key);
+        return uint8(vm.envUint(envvar));
+    }
+
+    /**
      * Returns a uin64 set in the current environment.
      * @param key The environment key. Corresponds to a ZEUS_* env variable.
      */

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -56,8 +56,6 @@ abstract contract ZeusScript is Script, Test {
     function zSetMultisigContext(address addr) public {
         require(vm.envBool("ZEUS_TEST"), "can only use zMockMultisig() during a test.");
         zUpdate(multisigContext, addr);
-        console.log("zeus test - updated multisig context");
-        console.log(addr);
     }
 
     function getMultisigContext() public view returns (address) {

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -31,6 +31,8 @@ abstract contract ZeusScript is Script, Test {
     string internal constant implSuffix = "_Impl";
     string internal constant proxySuffix = "_Proxy";
 
+    string internal constant multisigContext = "_internal_multisigContext";
+
     mapping(string => address) internal updatedContracts;
     mapping(string => EnvironmentVariableType) updatedTypes;
     mapping(string => string) updatedStrings;
@@ -48,6 +50,16 @@ abstract contract ZeusScript is Script, Test {
 
     function proxy(string memory contractName) public pure returns (string memory) {
         return contractName.concat(proxySuffix);
+    }
+
+    function zMockMultisig(address addr) public {
+        require(zBool("TEST"), "can only use zMockMultisig() during a test.");
+        updatedAddresses[multisigContext] = addr;
+    }
+
+    function getMockedMultisigContext() public view returns (address) {
+        require(updatedAddresses[multisigContext] != address(0));
+        return updatedAddresses[multisigContext];
     }
 
     /**

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -5,6 +5,7 @@ import {StringUtils} from "./StringUtils.sol";
 import {Script} from "forge-std/Script.sol";
 import {EncGnosisSafe} from "./EncGnosisSafe.sol";
 import {Test} from "forge-std/Test.sol";
+import {console} from "forge-std/console.sol";
 
 abstract contract ZeusScript is Script, Test {
     using StringUtils for string;
@@ -55,6 +56,8 @@ abstract contract ZeusScript is Script, Test {
     function zSetMultisigContext(address addr) public {
         require(vm.envBool("ZEUS_TEST"), "can only use zMockMultisig() during a test.");
         zUpdate(multisigContext, addr);
+        console.log("zeus test - updated multisig context");
+        console.log(addr);
     }
 
     function getMultisigContext() public view returns (address) {

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -52,15 +52,13 @@ abstract contract ZeusScript is Script, Test {
         return contractName.concat(proxySuffix);
     }
 
-    function zMockMultisig(address addr) public {
+    function zSetMultisigContext(address addr) public {
         require(vm.envBool("ZEUS_TEST"), "can only use zMockMultisig() during a test.");
-        updatedAddresses[multisigContext] = addr;
+        zUpdate(multisigContext, addr);
     }
 
-    function getMockedMultisigContext() public returns (address) {
-        require(updatedAddresses[multisigContext] != address(0));
-        updatedTypes[multisigContext] = EnvironmentVariableType.ADDRESS;
-        return updatedAddresses[multisigContext];
+    function getMultisigContext() public view returns (address) {
+        return zAddress(multisigContext);
     }
 
     /**

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -53,7 +53,7 @@ abstract contract ZeusScript is Script, Test {
     }
 
     function zMockMultisig(address addr) public {
-        require(zBool("TEST"), "can only use zMockMultisig() during a test.");
+        require(vm.envBool("ZEUS_TEST"), "can only use zMockMultisig() during a test.");
         updatedAddresses[multisigContext] = addr;
     }
 

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -31,7 +31,7 @@ abstract contract ZeusScript is Script, Test {
     string internal constant implSuffix = "_Impl";
     string internal constant proxySuffix = "_Proxy";
 
-    string internal constant multisigContext = "_internal_multisigContext";
+    string internal constant multisigContext = "MULTISIG";
 
     mapping(string => address) internal updatedContracts;
     mapping(string => EnvironmentVariableType) updatedTypes;

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -57,8 +57,9 @@ abstract contract ZeusScript is Script, Test {
         updatedAddresses[multisigContext] = addr;
     }
 
-    function getMockedMultisigContext() public view returns (address) {
+    function getMockedMultisigContext() public returns (address) {
         require(updatedAddresses[multisigContext] != address(0));
+        updatedTypes[multisigContext] = EnvironmentVariableType.ADDRESS;
         return updatedAddresses[multisigContext];
     }
 


### PR DESCRIPTION
- multisigs now use spoofing to specify the "source" of the call.
- tests can now be any `test*` method (as opposed to the previous designated method).
- added several convenience methods around numerical types.