### PR TITLE
zAssertDeployed / zAssertUpdate / zAssertClean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ docs/
 
 # Dotenv file
 .env
+
+.vscode

--- a/src/templates/EOADeployer.sol
+++ b/src/templates/EOADeployer.sol
@@ -10,6 +10,7 @@ import {ScriptHelpers} from "../utils/ScriptHelpers.sol";
  */
 abstract contract EOADeployer is ZeusScript {
     using ScriptHelpers for *;
+
     Deployment[] private _deployments;
 
     /**

--- a/src/utils/ScriptHelpers.sol
+++ b/src/utils/ScriptHelpers.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.12;
 
 library ScriptHelpers {
-
     string internal constant IMPL_SUFFIX = "_Impl";
     string internal constant PROXY_SUFFIX = "_Proxy";
 


### PR DESCRIPTION
`zAssertDeployed(name)` - assert that a contract with `name` was deployed.
`zAssertUpdated(name)` - assert that an environment parameter `name` was updated.
`zAssertClean()` - assert that all environment parameters + contract updates have been asserted. (prevents you from missing any).