### PR TITLE
feat: support multisig deploy

### DIFF
--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -12,6 +12,7 @@ import {ScriptHelpers} from "../utils/ScriptHelpers.sol";
 abstract contract MultisigBuilder is ZeusScript {
     using ZEnvHelpers for *;
     using ScriptHelpers for *;
+
     bool private hasPranked;
 
     modifier prank(address caller) {
@@ -68,11 +69,13 @@ abstract contract MultisigBuilder is ZeusScript {
     }
 
     /// @dev Only meant for use with deploying a contract from a multisig. Please ensure you know what you are doing if you call this!
+
     function _unsafeAddImplContract(string memory name, address deployedTo) internal {
         _addContract(name.impl(), deployedTo);
     }
 
     /// @notice Adds a contract to the environment.
+    /// @dev This function assumes that the contract is a singleton.
     function _addContract(string memory name, address deployedTo) private {
         emit ZeusDeploy(name, deployedTo, true /* singleton */ );
         ZEnvHelpers.state().__updateContract(name, deployedTo);

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.12;
 
+import "../utils/ZEnvHelpers.sol";
 import "../utils/ZeusScript.sol";
+import {ScriptHelpers} from "../utils/ScriptHelpers.sol";
 
 /**
  * @title MultisigBuilder
  * @dev Abstract contract for building arbitrary multisig scripts.
  */
 abstract contract MultisigBuilder is ZeusScript {
-    using ScriptHelpers for *;
     using ZEnvHelpers for *;
-
+    using ScriptHelpers for *;
     bool private hasPranked;
 
     modifier prank(address caller) {

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -8,6 +8,9 @@ import "../utils/ZeusScript.sol";
  * @dev Abstract contract for building arbitrary multisig scripts.
  */
 abstract contract MultisigBuilder is ZeusScript {
+    using ScriptHelpers for *;
+    using ZEnvHelpers for *;
+
     bool private hasPranked;
 
     modifier prank(address caller) {
@@ -56,5 +59,21 @@ abstract contract MultisigBuilder is ZeusScript {
     /// @dev Only meant for use with tests. Please ensure you know what you are doing if you call this!
     function _unsafeResetHasPranked() internal {
         hasPranked = false;
+    }
+
+    /// @dev Only meant for use with deploying a contract from a multisig. Please ensure you know what you are doing if you call this!
+    function _unsafeAddProxyContract(string memory name, address deployedTo) internal {
+        _addContract(name.proxy(), deployedTo);
+    }
+
+    /// @dev Only meant for use with deploying a contract from a multisig. Please ensure you know what you are doing if you call this!
+    function _unsafeAddImplContract(string memory name, address deployedTo) internal {
+        _addContract(name.impl(), deployedTo);
+    }
+
+    /// @notice Adds a contract to the environment.
+    function _addContract(string memory name, address deployedTo) private {
+        emit ZeusDeploy(name, deployedTo, false /* singleton */ );
+        ZEnvHelpers.state().__updateContract(name, deployedTo);
     }
 }

--- a/src/templates/MultisigBuilder.sol
+++ b/src/templates/MultisigBuilder.sol
@@ -74,7 +74,7 @@ abstract contract MultisigBuilder is ZeusScript {
 
     /// @notice Adds a contract to the environment.
     function _addContract(string memory name, address deployedTo) private {
-        emit ZeusDeploy(name, deployedTo, false /* singleton */ );
+        emit ZeusDeploy(name, deployedTo, true /* singleton */ );
         ZEnvHelpers.state().__updateContract(name, deployedTo);
     }
 }

--- a/src/utils/ZeusScript.sol
+++ b/src/utils/ZeusScript.sol
@@ -8,12 +8,14 @@ import {Script} from "forge-std/Script.sol";
 import {Test} from "forge-std/Test.sol";
 import {console} from "forge-std/console.sol";
 
-
 abstract contract ZeusScript is Script, Test {
     using StringUtils for string;
     using ZEnvHelpers for *;
 
-    enum OperationalMode {MULTISIG, EOA}
+    enum OperationalMode {
+        MULTISIG,
+        EOA
+    }
 
     OperationalMode public _mode;
 


### PR DESCRIPTION
To enable contracts to be deployed from multisigs, we need to emit `ZeusDeploy` events from `MuultisigBuilder`

Adds two functions which emit an event and update `ZEnvHelper` state
-  `_unsafeAddProxyContract`
- `_unsafeAddImplContract`